### PR TITLE
Fixed issue with importing index.js when deployed to AWS

### DIFF
--- a/src/src/http/get-login/index.mjs
+++ b/src/src/http/get-login/index.mjs
@@ -1,6 +1,4 @@
 import arc from '@architect/functions'
-import oauthPlugin from '../../../index.js'
-const loginHref = oauthPlugin.loginHref
 
 export const handler = arc.http.async(login)
 
@@ -10,4 +8,14 @@ async function login(req) {
     statusCode: 200,
     html: `<a href="${href}">Login with Github</a>`
   }
+}
+
+function loginHref() {
+  const redirectUrlPart = process.env.ARC_OAUTH_REDIRECT_URL
+    ? `&redirect_url=${process.env.ARC_OAUTH_REDIRECT_URL}`
+    : ''
+  if (process.env.ARC_OAUTH_USE_MOCK)
+    return 'http://localhost:3333/mock/auth/login'
+  else
+    return `https://github.com/login/oauth/authorize?client_id=${process.env.ARC_OAUTH_CLIENT_ID}${redirectUrlPart}`
 }


### PR DESCRIPTION
I've reinstated the earlier fix for issue #2 in my own fork, so I thought I'd share it here