### PR TITLE
Support Enhance

### DIFF
--- a/src/src/http/get-auth/authorize.mjs
+++ b/src/src/http/get-auth/authorize.mjs
@@ -1,18 +1,27 @@
 const useMock = process.env.ARC_OAUTH_USE_MOCK
 const useAllowList = process.env.ARC_OAUTH_USE_ALLOW_LIST
 const matchProperty = process.env.ARC_OAUTH_MATCH_PROPERTY
-let allowListPromise
-if (useAllowList && useMock)
-  allowListPromise = import(
-    `@architect/shared/${process.env.ARC_OAUTH_MOCK_ALLOW_LIST}`
-  )
-if (useAllowList && !useMock)
-  allowListPromise = import(
-    `@architect/shared/${process.env.ARC_OAUTH_ALLOW_LIST}`
-  )
+
+const loadModule = async (modulePath) => {
+  try {
+    // standard arc
+    return await import(
+      `@architect/shared/${modulePath}`
+    )
+  } catch (e) {
+    // enhance app
+    return await import(
+      `@architect/views/models/${modulePath}`
+    )
+  }
+}
 
 export default async function authorize(providerAccount) {
-  const allowList = (await allowListPromise).default
+  let allowList = null
+  if (useAllowList && useMock)
+    allowList = (await loadModule(process.env.ARC_OAUTH_MOCK_ALLOW_LIST)).default
+  if (useAllowList && !useMock)
+    allowList = (await loadModule(process.env.ARC_OAUTH_ALLOW_LIST)).default
   const appUser =
     allowList.appAccounts[providerAccount.oauth.user[matchProperty]]
   if (!appUser) return false


### PR DESCRIPTION
Enhance no longer creates a `models` folder that maps to `@architect/shared` so the mock imports fail. This is the best way I found to guard against the problem.